### PR TITLE
[Feature] Add replace methods

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -25,3 +25,19 @@ export const sanitizeSQL = sql => {
 };
 
 const _formatSQL = sql => sql.toLowerCase().trim();
+
+export const formatRows = async (format, rows) => {
+    let formattedRows;
+    switch (format) {
+        case 'csv':
+            formattedRows = await rowsToCSV(rows);
+            break;
+        case 'ndjson':
+            formattedRows = rowsToNDJSON(rows);
+            break;
+        case 'json':
+            formattedRows = JSON.stringify(rows);
+            break;
+    }
+    return formattedRows;
+};

--- a/test/datasources-tests.js
+++ b/test/datasources-tests.js
@@ -165,7 +165,47 @@ describe('Test Datasources API', () => {
 
             expect(characters.length).to.eq(0);
         } catch (error) {
-            console.log(error)
+            expect(error).to.be.null;
+        }
+    });
+
+    it('should replace datasource with rows', async () => {
+        try {
+            const rows = [
+                { name: 'Leia',   profession: 'Princess', age: 32 },
+                { name: 'Anakin', profession: 'Jedi',     age: 50 },
+                { name: 'Obi',    profession: 'Jedi',     age: 65 }
+            ];
+
+            // Avoid API throttling (429)
+            await new Promise(resolve => setTimeout(resolve, 30000));
+            await tb.replaceWithRows(datasourceName, rows);
+
+            const result = await tb.query(`select * from ${datasourceName}`);
+            const characters = result['data'];
+
+            expect(characters.length).to.eq(3);
+        } catch (error) {
+            expect(error).to.be.null;
+        }
+    });
+
+    it('should replace datasource with rows matching a condition', async () => {
+        try {
+            const rows = [
+                { name: 'Mace Windu', profession: 'Jedi', age: 50 }
+            ];
+
+            // Avoid API throttling (429)
+            await new Promise(resolve => setTimeout(resolve, 30000));
+            await tb.replaceWithRows(datasourceName, rows, 'csv', 'profession = \'Jedi\'');
+
+            const result = await tb.query(`select * from ${datasourceName} where profession = 'Jedi'`);
+            const characters = result['data'];
+
+            expect(characters.length).to.eq(1);
+            expect(characters[0]['name']).to.eq('Mace Windu');
+        } catch (error) {
             expect(error).to.be.null;
         }
     });
@@ -179,7 +219,6 @@ describe('Test Datasources API', () => {
 
             expect(characters.length).to.eq(0);
         } catch (error) {
-            console.log(error)
             expect(error).to.be.null;
         }
     });


### PR DESCRIPTION
Support `replace` mode when appending data to existing datasources.

**IMPORTANT:** PR is in draft status waiting for a bug on Tinybird to get fixed. As of today, the `replace` mode leaves the datasource inconsistent since it only deletes matching rows on some partitions.

#### Todo

- [x] Implement `replaceWithRows` method
- [ ] Implement `replaceWithFile` method
- [ ] Tests
- [ ] Docs